### PR TITLE
DT-2412 Add application platform documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 Staticfile.auth
 
 docs
+
+# Ignore Intellij
+.idea/

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -3,7 +3,7 @@ host: https://tech-docs.hmpps.service.justice.gov.uk
 
 # Header-related options
 show_govuk_logo: false
-service_name: HMPPS Tech Team docs
+service_name: DPS Tech Team docs
 service_link: /
 
 # Links to show on right-hand-side of header
@@ -23,10 +23,10 @@ enable_search: true
 ga_tracking_id:
 
 # Enable multipage navigation in the sidebar
-multipage_nav: false
+multipage_nav: true
 
 # Enable collapsible navigation in the sidebar
-collapsible_nav: false
+collapsible_nav: true
 
 # Table of contents depth – how many levels to include in the table of contents.
 # If your ToC is too long, reduce this number and we'll only show higher-level
@@ -39,3 +39,4 @@ prevent_indexing: true
 show_contribution_banner: true
 github_repo: ministryofjustice/hmpps-tech-docs
 github_branch: main
+

--- a/source/application-platform.html.md.erb
+++ b/source/application-platform.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: HMPPS Application Platform
-last_reviewed_on: 2021-09-03
+last_reviewed_on: 2021-09-06
 review_in: 3 months
 weight: 20
 ---

--- a/source/application-platform.html.md.erb
+++ b/source/application-platform.html.md.erb
@@ -1,0 +1,150 @@
+---
+title: HMPPS Application Platform
+last_reviewed_on: 2021-09-03
+review_in: 3 months
+weight: 20
+---
+
+# <%= current_page.data.title %>
+
+## Introduction
+
+This document describes the application platform used across HMPPS to share common development patterns.
+
+## About the HMPPS Application Platform
+
+The HMPPS Application Platform provides the core components developers need to start building applications quickly.
+
+This includes:
+
+* Template projects for frontend and backend services
+* A project generator to automatically configure projects and build pipelines
+* Build tools and plugins to use our standard build patterns
+* Generic alerts to monitor application status
+* Libraries for sharing common development patterns
+
+All of the above are designed to work with the [MOJ Cloud Platform](https://user-guide.cloud-platform.service.justice.gov.uk/#cloud-platform-user-guide).
+
+### Benefits of using the Application Platform
+
+The Application Platform captures various patterns that have matured within the DPS development community and makes them easy to adopt on new projects.
+
+#### Build new services quickly
+
+Historically development teams would spend several weeks working on Sprint Zero to create a build pipeline for their skeleton project. Often Sprint Zero is never completed and projects start with the burden of technical debt.
+
+By using our Project Bootstrapper it is possible to deploy a skeleton project to production in hours. This allows developers to quickly start delivering user stories and add value to the end users.
+
+#### Adopt common standards
+
+Innovation is encouraged but we don't want teams diverging too much. Otherwise we end up with many solutions to the same problems causing a maintenance headache for both developers and operations.
+
+By using standard components available in the Application Platform we can manage services in a consistent way and share best practice.
+
+#### Increase institutional knowledge
+
+As the trickle of new services turns into a flood we find that many projects are at different levels of maturity. These then require different levels of support from teams of different sizes.
+
+By using standard components we share knowledge of our development practices. This makes it easier to move developers between teams and provide the right levels of support where needed.
+
+#### Secure services
+
+Security is no longer an afterthought tagged onto the end of a project by overworked security and operations staff. To maintain a secure estate we must build security best practices in from the start of a project and in a consistent manner.
+
+By using our various build tools it's easier to keep services up to date with the latest security patches and identify security vulnerabilities.
+
+#### Add observability into services
+
+No service runs in isolation and gaining a holistic view of the whole estate presents difficult challenges. There are many open source technologies to help with observability but these need coordinating between services to be successful.
+
+By using our application templates we standardise the capturing of telemetry and tracing. This allow us to provide a common toolset for observing our suite of microservices.
+
+#### Take advantage of mature development patterns
+
+Many problems facing developers in HMPPS have been "solved" and using these patterns gives teams a head start.
+
+By using our various build plugins and libraries we have captured some of these patterns to distribute amongst teams. This allows developers to focus on providing value to end users.
+
+## Application Platform Shared Components
+
+### Project Bootstrapper
+
+The [project bootstrapper](https://github.com/ministryofjustice/dps-project-bootstrap) is a utility for generating new projects and/or configuring build pipelines for projects. It works by [defining a project](https://github.com/ministryofjustice/dps-project-bootstrap/blob/main/projects.json) and running a script to create and configure a Github project, a CircleCI project, a quay.io project and a Kubernetes namespace.
+
+The bootstrapper can be used to copy an existing Kotlin or Typescript template project or can run against an existing project.
+
+As well as removing the effort required to create a build pipeline it allows us to standardise things like Github project configuration.
+
+See the [project readme](https://github.com/ministryofjustice/dps-project-bootstrap) for usage details.
+
+### Kotlin Template
+
+The [Kotlin Template project](https://github.com/ministryofjustice/hmpps-template-kotlin) is a skeleton backend Kotlin / Spring Boot application. It can be copied to create a new project.
+
+The application is very light and provides little more than example health checks. The main value is gained from the CircleCI, Helm, Docker, Gradle and Application Insights configurations. These allow a new application to be built and deployed to a Kubernetes namespace. The template application itself runs in the namespace `hmpps-template-kotlin` on Cloud Platform as a test to prove it is deployable.
+
+The template works best in conjunction with the [Project Bootstrapper](#project-bootstrapper) which configures a build pipeline to get the application deployed into Kubernetes.
+
+Any questions or suggestions relating to the Kotlin template should be directed to MOJ Slack channel `#kotlin-dev`.
+
+### Typescript Template
+
+The [Typescript Template project](https://github.com/ministryofjustice/hmpps-template-typescript) is a skeleton frontend / Node application. It can be copied to create a new project.
+
+Note that this template is not a DPS Tech Team project but is community driven and owned by the MOJ Slack channel `#typescript`. It has been included here because it is a great fit with the other offerings.
+
+The application is very light but provides enough detail to get a skeleton application up and running. The template application itself runs in the namespace `hmpps-template-typescript` on Cloud Platform as a test to prove it is deployable.
+
+The template works best in conjunction with the [Project Bootstrapper](#project-bootstrapper) which configures a build pipeline to get the application deployed into Kubernetes.
+
+Any questions or suggestions relating to the Typescript template should be directed to MOJ Slack channel `#typescript`.
+
+### Gradle Build Plugin
+
+The [Gradle Plugin](https://github.com/ministryofjustice/dps-gradle-spring-boot) is used to orchestrate Gradle builds of Java/Kotlin Spring Boot projects. "Orchestrate" means it applies 3rd party Gradle plugins and configures them rather than adding new build logic. The plugins applied can be found in the [build.gradle.kts](https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/build.gradle.kts) file.
+
+One notable plugin that is applied to all projects is the [dependency check plugin](https://github.com/dependency-check/dependency-check-gradle). This is run in scheduled CircleCI builds to find vulnerabilities in our dependencies. It also includes a way of suppressing [false positives](https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/main/src/main/resources/dps-gradle-spring-boot-suppressions.xml).
+
+Please see the [project readme](https://github.com/ministryofjustice/dps-gradle-spring-boot) for more information on the plugin.
+
+Note that the plugin is used in our [Kotlin Template project](#kotlin-template).
+
+### CircleCI Orb
+
+The [CircleCI Orb](https://github.com/ministryofjustice/hmpps-circleci-orb) is a plugin used in CircleCI builds to provide standard build executions, jobs and commands.
+
+Jobs exist to perform common tasks such as building and publishing docker images, deploying to environments and running security checks.
+
+Common commands include installing build tools such as AWS CLI and helm and a standard way of generating application versions.
+
+Default executors are available for building different development stacks.
+
+Note that a default CircleCI build using the relevant Orb components is included in both the [Kotlin Template project](#kotlin-template) and the [Typescript Template project](#typescript-template) (in the directory `.circleci`).
+
+More details can be found on the [Orb's registry page](https://circleci.com/developer/orbs/orb/ministryofjustice/hmpps).
+
+### Helm Charts
+
+The [HMPPS Helm Charts project](https://github.com/ministryofjustice/hmpps-helm-charts) provides generic Helm charts that can be used by any service. These are Helm templates with various extension points that can be configured in Helm values files.
+
+A [generic service chart](https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-service) is available to deploy any service into the Kubernetes instance hosted by Cloud Platforms.
+
+A [generic prometheus alerts chart](https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/generic-prometheus-alerts) provides a standard set of alerts for Kubernetes deployments and ingresses.
+
+A [ClamAV chart](https://github.com/ministryofjustice/hmpps-helm-charts/tree/main/charts/clamav) adds an antivirus utility to a namespace.
+
+Note that the generic service chart and generic prometheus alerts chart are used by both the [Kotlin Template project](#kotlin-template) and the [Typescript Template project](#typescript-template) (in the directory `helm_deploy`).
+
+### Spring Boot SQS Starter Library
+
+The [hmpps-spring-boot-sqs project](https://github.com/ministryofjustice/hmpps-spring-boot-sqs) publishes a Spring Boot starter library for using AWS SQS and SNS in a standard HMPPS way.
+
+The library captures various patterns for using the AWS SQS and SNS client libraries that have been widely adopted within HMPPS. These patterns include creating secure clients, JMS listeners, queue health indicators, retry/purge endpoints and integration with the AWS testing utility Localstack.
+
+To see an example of the library in action look at the project's [test application](https://github.com/ministryofjustice/hmpps-spring-boot-sqs/tree/main/test-app) which is used for both functional tests and can be spun up locally. The library has also been used in [several projects](https://github.com/search?q=org%3Aministryofjustice+hmpps-sqs-spring-boot-starter&type=code) and these provide good real life examples.
+
+## Creating A New Service
+
+Coming soon...
+
+

--- a/source/application-platform.html.md.erb
+++ b/source/application-platform.html.md.erb
@@ -7,8 +7,6 @@ weight: 20
 
 # <%= current_page.data.title %>
 
-## Introduction
-
 This document describes the application platform used across HMPPS to share common development patterns.
 
 ## About the HMPPS Application Platform

--- a/source/application-platform.html.md.erb
+++ b/source/application-platform.html.md.erb
@@ -69,13 +69,18 @@ By using our various build plugins and libraries we have captured some of these 
 
 ### Project Bootstrapper
 
-The [project bootstrapper](https://github.com/ministryofjustice/dps-project-bootstrap) is a utility for generating new projects and/or configuring build pipelines for projects. It works by [defining a project](https://github.com/ministryofjustice/dps-project-bootstrap/blob/main/projects.json) and running a script to create and configure a Github project, a CircleCI project, a quay.io project and a Kubernetes namespace.
+The project bootstrapper is a utility for generating new projects and/or configuring build pipelines for projects. It works by defining a project in the `projects.json` file and running a script to create and configure a GitHub project, a CircleCI project, a quay.io project and a Kubernetes namespace.
 
 The bootstrapper can be used to copy an existing Kotlin or Typescript template project or can run against an existing project.
 
-As well as removing the effort required to create a build pipeline it allows us to standardise things like Github project configuration.
+As well as removing the effort required to create a build pipeline it allows us to standardise things like GitHub project configuration.
 
-See the [project readme](https://github.com/ministryofjustice/dps-project-bootstrap) for usage details.
+See the project readme on GitHub for usage details.
+
+#### External links (requires login to GitHub)
+
+GitHub project: https://github.com/ministryofjustice/dps-project-bootstrap
+projects.json file: https://github.com/ministryofjustice/dps-project-bootstrap/blob/main/projects.json
 
 ### Kotlin Template
 

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: DPS Tech Team docs
-last_reviewed_on: 2021-03-18
+last_reviewed_on: 2021-09-06
 review_in: 3 months
 weight: 0
 ---

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -1,99 +1,15 @@
 ---
-title: HMPPS Tech Team docs
+title: DPS Tech Team docs
 last_reviewed_on: 2021-03-18
 review_in: 3 months
+weight: 0
 ---
 
 # <%= current_page.data.title %>
 
-## Who is this documentation for?
+## Introduction
 
-This documentation describes what standards we adhere to when writing our services, as well as providing guidelines for interaction.
-
-### README
-All our services should have a github README.md at the root of their repository. Information in this should include:
-
-* Who to contact with any questions
-* Where the API docs are located
-* How to call the endpoints and whether any authentication / special authorisation is required
-* How to check that the service is up and running i.e. the health endpoint
-* How to check that the service is responding to requests i.e. the ping endpoint
-* How to find out the version of the deployed application and link it back to a specific git commit.
-* How to rollback a deployed service to a previous version
-* How to run the application locally
-
-## Publishing APIs
-All services should have clear API documentation that details the endpoints with the authorisation requirements.
-
-The API documentation should be in OpenAPI 3 format, according to [GDS guidelines][openapi-3].
-It should include examples for the various data elements as well as the possible values for constrained items.
-
-## Coding standards
-All our code is peer reviewed before being merged and then released.
-All commits should include a JIRA reference so that we can trace back the reasons for the change etc.
-
-### Breaking changes
-We follow these principles for each of our endpoints:
-
-* We do not take anything away
-* We do not change processing rules
-* We do not make optional things required
-* Anything we add must be optional
-
-Consumers need to be resilient enough to support these changes, e.g. they shouldn't bind tightly to an expected representation as new fields may be added at a later date.
-
-This means that a new endpoint should be added instead of making a breaking change to an existing endpoint.
-Since we know what clients call which endpoints we can then inform the clients to switch to the new endpoint.
-When all the clients have switched over we can then remove the old endpoint.
-
-### Releases
-We will endevour to release as soon as a new feature has been tested, rather than bulking up multiple changes into a release.
-If an application release contains multiple changes since the last release then it is important that agreement with all the changers is sought before release.
-A changelog will be generated containing all the changes since the last release to production and it will be posted in the appropriate slack channel.
-
-## Service endpoints
-
-### `/health`
-Our services all provide a `/health` endpoint which checks all dependencies are healthy (e.g. database connection) and returns a http status of 200 if everything is up and running.
-The endpoint shouldn't then call `/health` on any of the dependencies though as this will create cascading health checks so that one health check could call health checks in the dependencies, which could then call health checks in the dependencies etc.
-This is called on a regular basis by our Pingdom check, which will then alert to us in slack in #dps_alerts if there are issues.
-It is also called by the DPS Monitor at https://dps-monitor.prison.service.justice.gov.uk/health to provide a dashboard of all the DPS services health.
-
-### `/ping`
-This is a simple check that will just return a http status of 200 if the application is up and running.
-It is therefore entirely suited to be called by other applications' health checks and also by kubernetes liveness and readiness probes if the application framework doesn't provide specific endpoints.
-
-### `/info`
-This provides basic information in a json format about the current application version, github commit reference and other useful application information.
-
-## Deployments
-
-Our release candidates are automatically deployed to our development environments using circleci.
-When a ticket has been successfully tested it is then approved for deployment to a production like environment before then being deployed to production.
-
-### Helm
-We use helm to manage the kubernetes deployments and configuration.
-A helm_deploy/README is included in all projects to provide information on how to find out the current deployed version and also to rollback to previous vresions.
-
-## Monitoring
-
-We use [azure monitor][azure-monitor] and in particular application insights to monitor our production systems.
-Our applications logs are ingested, as well as requests, exceptions and dependency calls.
-This means that we can tell how long requests take in our systems and how long each of the individual dependencies (e.g. database interactions) take.
-
-### Logging requests with individual clients
-All HMPPS Auth tokens contain a `client_id` and optionally a `user_name`.
-Each frontend application / service is issued with a different `client_id` so therefore this will uniquely identify a client.
-For system to system interaction the `user_name` will normally be empty.
-Both should then be included as extra attributes in the request logging so that clients can be identified and therefore we can track what clients are calling what endpoints and how often.
-
-### Correlating requests
-We confirm to [W3C tracing guidelines][w3c-tracing].
-This means that we accept a `traceparent` header which can then be used to correlate requests across all applications and to identify a user's journey through the application stack.
-
-### Application version
-All our requests are also augmented with the current version of the application to help identify when issues first occurred and link back to the correct code.
-This is of format <date>.<circleci job number>.<github reference> so can be traced back not only to the circleci job that built the code, but also the github commit of the code.
+This documentation describes the products, platforms and standards produced by the DPS Tech Team.
 
 ## Adding to the documentation
 
@@ -102,7 +18,3 @@ article, or if you're comfortable writing one yourself, PRs will be gratefully
 received. Details on how to get in touch are in the "Getting Help" section above, and
 the "GitHub" link at the top right of this page will take you to the repository for this
 guide.
-
-[openapi-3]: https://www.gov.uk/government/publications/recommended-open-standards-for-government/describing-restful-apis-with-openapi-3 "Describing RESTful APIs with OpenAPI 3"
-[azure-monitor]: https://docs.microsoft.com/en-us/azure/azure-monitor/ "Azure Monitor documentation"
-[w3c-tracing]: https://www.w3.org/TR/trace-context/ "Trace Context"

--- a/source/index.html.md.erb
+++ b/source/index.html.md.erb
@@ -7,8 +7,6 @@ weight: 0
 
 # <%= current_page.data.title %>
 
-## Introduction
-
 This documentation describes the products, platforms and standards produced by the DPS Tech Team.
 
 ## Adding to the documentation

--- a/source/service-standards.html.md.erb
+++ b/source/service-standards.html.md.erb
@@ -7,8 +7,6 @@ weight: 10
 
 # <%= current_page.data.title %>
 
-## Introduction
-
 This documentation describes the standards we adhere to when writing services.
 
 ## README

--- a/source/service-standards.html.md.erb
+++ b/source/service-standards.html.md.erb
@@ -1,6 +1,6 @@
 ---
 title: Service Standards
-last_reviewed_on: 2021-03-18
+last_reviewed_on: 2021-09-06
 review_in: 3 months
 weight: 10
 ---
@@ -48,7 +48,7 @@ Since we know what clients call which endpoints we can then inform the clients t
 When all the clients have switched over we can then remove the old endpoint.
 
 ### Releases
-We will endevour to release as soon as a new feature has been tested, rather than bulking up multiple changes into a release.
+We will endeavour to release as soon as a new feature has been tested, rather than bulking up multiple changes into a release.
 If an application release contains multiple changes since the last release then it is important that agreement with all the changers is sought before release.
 A changelog will be generated containing all the changes since the last release to production and it will be posted in the appropriate slack channel.
 
@@ -74,7 +74,7 @@ When a ticket has been successfully tested it is then approved for deployment to
 
 ### Helm
 We use helm to manage the kubernetes deployments and configuration.
-A helm_deploy/README is included in all projects to provide information on how to find out the current deployed version and also to rollback to previous vresions.
+A helm_deploy/README is included in all projects to provide information on how to find out the current deployed version and also to rollback to previous versions.
 
 ## Monitoring
 

--- a/source/service-standards.html.md.erb
+++ b/source/service-standards.html.md.erb
@@ -1,0 +1,101 @@
+---
+title: Service Standards
+last_reviewed_on: 2021-03-18
+review_in: 3 months
+weight: 10
+---
+
+# <%= current_page.data.title %>
+
+## Introduction
+
+This documentation describes the standards we adhere to when writing services.
+
+## README
+All our services should have a github README.md at the root of their repository. Information in this should include:
+
+* Who to contact with any questions
+* Where the API docs are located
+* How to call the endpoints and whether any authentication / special authorisation is required
+* How to check that the service is up and running i.e. the health endpoint
+* How to check that the service is responding to requests i.e. the ping endpoint
+* How to find out the version of the deployed application and link it back to a specific git commit.
+* How to rollback a deployed service to a previous version
+* How to run the application locally
+
+## Publishing APIs
+All services should have clear API documentation that details the endpoints with the authorisation requirements.
+
+The API documentation should be in OpenAPI 3 format, according to [GDS guidelines][openapi-3].
+It should include examples for the various data elements as well as the possible values for constrained items.
+
+## Coding standards
+All our code is peer reviewed before being merged and then released.
+All commits should include a JIRA reference so that we can trace back the reasons for the change etc.
+
+### Breaking changes
+We follow these principles for each of our endpoints:
+
+* We do not take anything away
+* We do not change processing rules
+* We do not make optional things required
+* Anything we add must be optional
+
+Consumers need to be resilient enough to support these changes, e.g. they shouldn't bind tightly to an expected representation as new fields may be added at a later date.
+
+This means that a new endpoint should be added instead of making a breaking change to an existing endpoint.
+Since we know what clients call which endpoints we can then inform the clients to switch to the new endpoint.
+When all the clients have switched over we can then remove the old endpoint.
+
+### Releases
+We will endevour to release as soon as a new feature has been tested, rather than bulking up multiple changes into a release.
+If an application release contains multiple changes since the last release then it is important that agreement with all the changers is sought before release.
+A changelog will be generated containing all the changes since the last release to production and it will be posted in the appropriate slack channel.
+
+## Service endpoints
+
+### `/health`
+Our services all provide a `/health` endpoint which checks all dependencies are healthy (e.g. database connection) and returns a http status of 200 if everything is up and running.
+The endpoint shouldn't then call `/health` on any of the dependencies though as this will create cascading health checks so that one health check could call health checks in the dependencies, which could then call health checks in the dependencies etc.
+This is called on a regular basis by our Pingdom check, which will then alert to us in slack in #dps_alerts if there are issues.
+It is also called by the DPS Monitor at https://dps-monitor.prison.service.justice.gov.uk/health to provide a dashboard of all the DPS services health.
+
+### `/ping`
+This is a simple check that will just return a http status of 200 if the application is up and running.
+It is therefore entirely suited to be called by other applications' health checks and also by kubernetes liveness and readiness probes if the application framework doesn't provide specific endpoints.
+
+### `/info`
+This provides basic information in a json format about the current application version, github commit reference and other useful application information.
+
+## Deployments
+
+Our release candidates are automatically deployed to our development environments using circleci.
+When a ticket has been successfully tested it is then approved for deployment to a production like environment before then being deployed to production.
+
+### Helm
+We use helm to manage the kubernetes deployments and configuration.
+A helm_deploy/README is included in all projects to provide information on how to find out the current deployed version and also to rollback to previous vresions.
+
+## Monitoring
+
+We use [azure monitor][azure-monitor] and in particular application insights to monitor our production systems.
+Our applications logs are ingested, as well as requests, exceptions and dependency calls.
+This means that we can tell how long requests take in our systems and how long each of the individual dependencies (e.g. database interactions) take.
+
+### Logging requests with individual clients
+All HMPPS Auth tokens contain a `client_id` and optionally a `user_name`.
+Each frontend application / service is issued with a different `client_id` so therefore this will uniquely identify a client.
+For system to system interaction the `user_name` will normally be empty.
+Both should then be included as extra attributes in the request logging so that clients can be identified and therefore we can track what clients are calling what endpoints and how often.
+
+### Correlating requests
+We confirm to [W3C tracing guidelines][w3c-tracing].
+This means that we accept a `traceparent` header which can then be used to correlate requests across all applications and to identify a user's journey through the application stack.
+
+### Application version
+All our requests are also augmented with the current version of the application to help identify when issues first occurred and link back to the correct code.
+This is of format <date>.<circleci job number>.<github reference> so can be traced back not only to the circleci job that built the code, but also the github commit of the code.
+
+[openapi-3]: https://www.gov.uk/government/publications/recommended-open-standards-for-government/describing-restful-apis-with-openapi-3 "Describing RESTful APIs with OpenAPI 3"
+[azure-monitor]: https://docs.microsoft.com/en-us/azure/azure-monitor/ "Azure Monitor documentation"
+[w3c-tracing]: https://www.w3.org/TR/trace-context/ "Trace Context"


### PR DESCRIPTION
This first pass adds 2 sections about the Application Platform - a non-technical section (`About the HMPPS Application Platform`) highlighting the benefits of using the shared components, then a technical section (`Application Platform Shared Components`) with more details and signposts to the various project readmes.  An example of building a new service is coming next.